### PR TITLE
fix issue: no module named 'packaging'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    install_requires=["sphinx"],
+    install_requires=["sphinx>=1.7.0"],
     entry_points={
         "pygments.styles": [
             "pocoo = pallets_sphinx_themes.themes.pocoo:PocooStyle",


### PR DESCRIPTION
As issue #9 said, ``packaging`` is required. So limit ``sphinx`` version greater than 1.7.0 and it will bring ``packaging`` library together.