### PR TITLE
solution 2: no module named 'packaging'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    install_requires=["sphinx"],
+    install_requires=["sphinx", "packaging"],
     entry_points={
         "pygments.styles": [
             "pocoo = pallets_sphinx_themes.themes.pocoo:PocooStyle",


### PR DESCRIPTION
Another solution for the issue #9 :
1. Declare a dependency on 'packaging'.
2. Don't worry about sphinx's dependence changes.