### PR TITLE
Fix issue #15: ImportError: cannot import name 'DocVersion' 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,26 @@
 import io
+import os
 
 from setuptools import find_packages
 from setuptools import setup
 
 with io.open("README.rst", "rt", encoding="utf8") as f:
     readme = f.read()
+
+
+def get_sphinx_html_themes():
+    """Get sphinx.html_themes entry_points without importing package."""
+    themes = []
+    package = "pallets_sphinx_themes"
+    base = os.path.join(os.path.dirname(__file__), "src", package, "themes")
+
+    for name in os.listdir(base):
+        path = os.path.join(base, name)
+        if os.path.isdir(path):
+            themes.append("%s = %s" % (name, package))
+
+    return themes
+
 
 setup(
     name="Pallets-Sphinx-Themes",
@@ -21,6 +37,7 @@ setup(
     zip_safe=False,
     install_requires=["sphinx", "packaging"],
     entry_points={
+        "sphinx.html_themes": get_sphinx_html_themes(),
         "pygments.styles": [
             "pocoo = pallets_sphinx_themes.themes.pocoo:PocooStyle",
             "jinja = pallets_sphinx_themes.themes.jinja:JinjaStyle",

--- a/src/pallets_sphinx_themes/__init__.py
+++ b/src/pallets_sphinx_themes/__init__.py
@@ -12,7 +12,7 @@ from sphinx.errors import ExtensionError
 
 from .theme_check import only_pallets_theme
 from .theme_check import set_is_pallets_theme
-from .versions import load_versions
+from .versions import load_versions, DocVersion
 
 
 def setup(app):


### PR DESCRIPTION
## 2 changes to fix issue #15

* Expose ``DocVersion`` api in the package level for backwards compatibility

* Add ``sphinx.html_themes`` entry points, so ``sphinx`` can load extension themes from them.