### PR TITLE
fix RTD search override

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+Version 1.1.3
+=============
+
+Unreleased
+
+-   Move the Read the Docs search flag to the ``footer`` block to ensure
+    it executes after Read the Docs injects its data. (`#20`_)
+
+.. _#20: https://github.com/pallets/pallets-sphinx-themes/pull/20
+
+
 Version 1.1.2
 =============
 

--- a/src/pallets_sphinx_themes/themes/pocoo/layout.html
+++ b/src/pallets_sphinx_themes/themes/pocoo/layout.html
@@ -10,16 +10,6 @@
     <link rel="canonical" href="{{ canonical_url }}">
   {%- endif %}
   <script>DOCUMENTATION_OPTIONS.URL_ROOT = '{{ url_root }}';</script>
-  {%- if READTHEDOCS and not readthedocs_docsearch %}
-    <script>
-      if (typeof READTHEDOCS_DATA !== 'undefined') {
-        if (!READTHEDOCS_DATA.features) {
-          READTHEDOCS_DATA.features = {};
-        }
-        READTHEDOCS_DATA.features.docsearch_disabled = true;
-      }
-    </script>
-  {%- endif %}
   {{ super() }}
 {%- endblock %}
 
@@ -44,3 +34,17 @@
   <span id="sidebar-top"></span>
   {{- super() }}
 {%- endblock %}
+
+{% block footer %}
+  {{ super() }}
+  {%- if READTHEDOCS and not readthedocs_docsearch %}
+    <script>
+      if (typeof READTHEDOCS_DATA !== 'undefined') {
+        if (!READTHEDOCS_DATA.features) {
+          READTHEDOCS_DATA.features = {};
+        }
+        READTHEDOCS_DATA.features.docsearch_disabled = true;
+      }
+    </script>
+  {%- endif %}
+{% endblock %}


### PR DESCRIPTION
Move override to `footer` at end of `body`, since RTD always injects its code at end of `head`.