### PR TITLE
Use HTTPS links for font loading

### DIFF
--- a/src/pallets_sphinx_themes/themes/babel/static/babel.css
+++ b/src/pallets_sphinx_themes/themes/babel/static/babel.css
@@ -1,6 +1,6 @@
 @import url(pocoo.css);
-@import url(http://fonts.googleapis.com/css?family=Ubuntu+Mono:400,400italic,700,700italic);
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300,400);
+@import url(https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,400italic,700,700italic);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400);
 
 /* fonts */
 body                        { font-family: 'Ubuntu Mono', 'Consolas', 'Menlo',

--- a/src/pallets_sphinx_themes/themes/click/static/click.css
+++ b/src/pallets_sphinx_themes/themes/click/static/click.css
@@ -1,6 +1,6 @@
 @import url("pocoo.css");
-@import url("http://fonts.googleapis.com/css?family=Ubuntu+Mono");
-@import url("http://fonts.googleapis.com/css?family=Open+Sans");
+@import url("https://fonts.googleapis.com/css?family=Ubuntu+Mono");
+@import url("https://fonts.googleapis.com/css?family=Open+Sans");
 
 body, pre, code {
   font-family: "Ubuntu Mono", "Consolas", "Menlo", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;

--- a/src/pallets_sphinx_themes/themes/platter/static/platter.css
+++ b/src/pallets_sphinx_themes/themes/platter/static/platter.css
@@ -1,5 +1,5 @@
 @import url(pocoo.css);
-@import url(http://fonts.googleapis.com/css?family=Fira+Mono:400,700|Bitter:400,400italic,700);
+@import url(https://fonts.googleapis.com/css?family=Fira+Mono:400,700|Bitter:400,400italic,700);
 
 /* fonts */
 body                        { font-family: 'Bitter', serif; font-size: 16px; }


### PR DESCRIPTION
- This is necessary to avoid mixed content warnings

<img width="918" alt="Screen Shot 2019-03-22 at 12 56 10 PM" src="https://user-images.githubusercontent.com/185043/54849568-e7910f80-4ca1-11e9-9996-daf292bf63a1.png">
