### PR TITLE
sort versions from RTD

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Version 1.2.1
+-------------
+
+Unreleased
+
+-   Sort versions taken from Read the Docs so that 2.10.x is considered
+    newer than 2.9.x. :issue:`24`
+
+
 Version 1.2.0
 -------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Pallets-Sphinx-Themes
-version = 1.2.0
+version = 1.2.1.dev0
 url = https://sphinx-themes.palletsprojects.com/
 project_urls =
     Documentation = https://sphinx-themes.palletsprojects.com/


### PR DESCRIPTION
Ensures 2.10.x is reported higher than 2.9.x.

closes #24 