### PR TITLE
Make version warning sticky

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Version 1.2.2
+-------------
+
+Unreleased
+
+-   Make the version warning sticky so that it appears when linking to
+    the middle of a document. :issue:`5`
+
+
 Version 1.2.1
 -------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Pallets-Sphinx-Themes
-version = 1.2.1
+version = 1.2.2.dev0
 url = https://sphinx-themes.palletsprojects.com/
 project_urls =
     Documentation = https://sphinx-themes.palletsprojects.com/

--- a/src/pallets_sphinx_themes/themes/pocoo/layout.html
+++ b/src/pallets_sphinx_themes/themes/pocoo/layout.html
@@ -47,4 +47,5 @@
       }
     </script>
   {%- endif %}
+  {{ js_tag("_static/version_warning_offset.js") }}
 {% endblock %}

--- a/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
+++ b/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
@@ -162,6 +162,9 @@ div.carbon_ads a.carbon-poweredby {
 /* -- version warning ----------------------------------------------- */
 
 p.version-warning {
+  top: 10px;
+  position: sticky;
+
   margin: 10px 0;
   padding: 5px 10px;
   border-radius: 4px;

--- a/src/pallets_sphinx_themes/themes/pocoo/static/version_warning_offset.js
+++ b/src/pallets_sphinx_themes/themes/pocoo/static/version_warning_offset.js
@@ -1,0 +1,40 @@
+/*
+When showing the sticky version warning, the warning will cover the
+scroll target when navigating to #id hash locations. Take over scrolling
+to adjust the position to account for the height of the warning.
+*/
+$(() => {
+  const versionWarning = $('.version-warning')
+
+  // Skip if there is no version warning, regular browser behavior is
+  // fine in that case.
+  if (versionWarning.length) {
+    const height = versionWarning.outerHeight(true)
+    const target = $(':target')
+
+    // Adjust position when the initial link has a hash.
+    if (target.length) {
+      // Use absolute scrollTo instead of relative scrollBy to avoid
+      // scrolling when the viewport is already at the bottom of the
+      // document and has space.
+      const y = target.offset().top - height
+      // Delayed because the initial browser scroll doesn't seem to
+      // happen until after the document ready event, so scrolling
+      // immediately will be overridden.
+      setTimeout(() => scrollTo(0, y), 100)
+    }
+
+    // Listen to clicks on hash anchors.
+    $('a[href^="#"]').on('click', e => {
+      // Stop default scroll. Also stops the automatic URL hash update.
+      e.preventDefault()
+      // Get the id to scroll to and set the URL hash manually.
+      const id = $(e.currentTarget).attr('href').substring(1)
+      location.hash = id
+      // Use getElementById since the hash may have dots in it.
+      const target = $(document.getElementById(id))
+      // Scroll to top of target with space for the version warning.
+      scrollTo(0, target.offset().top - height)
+    })
+  }
+})


### PR DESCRIPTION
Uses `position: sticky` to make the version warning always visible rather than only at the top of the document. Adds JavaScript to take over scrolling when the warning is shown so that it doesn't overlap the target when navigating to `#id` hashes.

closes #5 