### PR TITLE
Fix importlib_metadata dependency for py3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ package_dir =
 include_package_data = true
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 install_requires =
-    importlib-metadata
+    importlib-metadata;python_version<"3.8"
     packaging
     Sphinx
 

--- a/src/pallets_sphinx_themes/__init__.py
+++ b/src/pallets_sphinx_themes/__init__.py
@@ -5,7 +5,6 @@ import sys
 import textwrap
 from collections import namedtuple
 
-import importlib_metadata
 from sphinx.builders._epub_base import EpubBuilder
 from sphinx.errors import ExtensionError
 
@@ -18,6 +17,12 @@ try:
 except ImportError:
     # Sphinx 1 compatibility
     from sphinx.builders.html import SingleFileHTMLBuilder
+
+try:
+    from importlib import metadata as importlib_metadata
+except ImportError:
+    # Python <3.8 compatibility
+    import importlib_metadata
 
 
 def setup(app):


### PR DESCRIPTION
This went into the stdlib in py 3.8, so use that when possible.
For <3.8, continue using the backport.