### PR TITLE
Add style for sphinx-tabs extension

### DIFF
--- a/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
+++ b/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
@@ -481,3 +481,30 @@ table.footnote td {
   white-space: nowrap;
   border: 0;
 }
+
+/* -- sphinx-tabs -------------------------------------------------- */
+
+.sphinx-tabs {
+  margin-bottom: 0;
+}
+
+.sphinx-tabs .ui.menu {
+  font-family: 'Garamond', 'Georgia', serif !important;
+}
+
+.sphinx-tabs .ui.attached.menu {
+  border-bottom: none
+}
+
+.sphinx-tabs .ui.tabular.menu .item {
+  border-bottom: 2px solid transparent;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  padding: .3em 0.6em;
+}
+
+.sphinx-tabs .ui.attached.segment, .ui.segment {
+  border: 0;
+  padding: 0;
+}


### PR DESCRIPTION
Add style for the new Sphinx extension (sphinx-tabs) introduced in Flask documentation (https://github.com/pallets/flask/pull/3714). This is the original style:

![image-20200802130954306](https://user-images.githubusercontent.com/12967000/89125722-17495c00-d513-11ea-9183-5fe428f9681b.png)

The is the improved style (it may still need to improve):

![image-20200802131211668](https://user-images.githubusercontent.com/12967000/89125738-2a5c2c00-d513-11ea-8b3d-216003f392a8.png)


