### PR TITLE
remove workaround for dirhtml search bug

### DIFF
--- a/src/pallets_sphinx_themes/themes/pocoo/layout.html
+++ b/src/pallets_sphinx_themes/themes/pocoo/layout.html
@@ -9,7 +9,6 @@
   {%- if page_canonical_url %}
     <link rel="canonical" href="{{ page_canonical_url }}">
   {%- endif %}
-  <script>DOCUMENTATION_OPTIONS.URL_ROOT = '{{ url_root }}';</script>
   {{ super() }}
 {%- endblock %}
 


### PR DESCRIPTION
Bug was fixed by sphinx, but variable was removed, so we were now causing the same bug.

- fixes #39 
- reverts #3