### PR TITLE
add sidebar for ethicalads.io ad placement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Unreleased
     causing the issue again. :issue:`39`
 -   Remove ``html_context["readthedocs_docsearch"]`` for controlling
     whether Read the Docs' search is used. :issue:`40`
+-   Add an ``ethicalads.html`` sidebar to have Read the Docs always show
+    ads in the sidebar instead of other possible locations. The sidebar
+    is enabled by default at the end of the list. :issue:`41`
 
 
 Version 2.0.0

--- a/src/pallets_sphinx_themes/themes/pocoo/ethicalads.html
+++ b/src/pallets_sphinx_themes/themes/pocoo/ethicalads.html
@@ -1,0 +1,1 @@
+<div id="ethical-ad-placement"></div>

--- a/src/pallets_sphinx_themes/themes/pocoo/theme.conf
+++ b/src/pallets_sphinx_themes/themes/pocoo/theme.conf
@@ -2,7 +2,7 @@
 inherit = basic
 stylesheet = pocoo.css
 pygments_style = pocoo
-sidebars = localtoc.html, relations.html, searchbox.html
+sidebars = localtoc.html, relations.html, searchbox.html, ethicalads.html
 
 [options]
 index_sidebar_logo = True


### PR DESCRIPTION
This causes Read the Docs to always place the ad in the sidebar.

fixes #41