### PR TITLE
Improve text alignment for better aesthetics

### DIFF
--- a/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
+++ b/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
@@ -5,6 +5,7 @@
 body {
   font-family: 'Garamond', 'Georgia', serif;
   font-size: 17px;
+  text-align: justify;
   background-color: #fff;
   color: #3e4349;
   margin: 0;


### PR DESCRIPTION
Currently, the text alignment of paragraphs is by default which looks not so beautiful.

![no-justify](https://user-images.githubusercontent.com/24974936/122789107-88d7f780-d2e9-11eb-8fdf-d131307c5238.png)

This PR would improve the text alignment for better aesthetics.

![justify](https://user-images.githubusercontent.com/24974936/122789114-8bd2e800-d2e9-11eb-974d-1201dfe4f763.png)
