### PR TITLE
Revert "Improve text alignment for better aesthetics"

### DIFF
--- a/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
+++ b/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
@@ -5,7 +5,6 @@
 body {
   font-family: 'Garamond', 'Georgia', serif;
   font-size: 17px;
-  text-align: justify;
   background-color: #fff;
   color: #3e4349;
   margin: 0;


### PR DESCRIPTION
Reverts pallets/pallets-sphinx-themes#49

Based on the discussion in https://github.com/sphinx-doc/sphinx/pull/9400, I suggest reverting @49. It may look elegant and beautiful to justify the content, but it will cause a bad reading experience when you notice the different whitespace widths.