### PR TITLE
fix dirhtml canonical url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Version 2.0.2
 
 Unreleased
 
+-   Detect if Sphinx dirhtml builder is generating canonical URLs with
+    ".html" and replace with the correct dir URL. :issue:`47`
+-   ``canonical_url`` config is deprecated. Use Sphinx's built-in
+    ``html_baseurl`` config instead. :pr:`53`
+
 
 Version 2.0.1
 -------------

--- a/src/pallets_sphinx_themes/themes/pocoo/layout.html
+++ b/src/pallets_sphinx_themes/themes/pocoo/layout.html
@@ -5,13 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 {%- endset %}
 
-{% block extrahead %}
-  {%- if page_canonical_url %}
-    <link rel="canonical" href="{{ page_canonical_url }}">
-  {%- endif %}
-  {{ super() }}
-{%- endblock %}
-
 {% block sidebarlogo %}
   {% if pagename != "index" or theme_index_sidebar_logo %}
     {{ super() }}


### PR DESCRIPTION
Sphinx 1.8 added support for outputting canonical URLs based on the `html_baseurl` config. However, the dirhtml builder doesn't override the value, so it uses the standard html url that ends with `.html`. See https://github.com/sphinx-doc/sphinx/issues/9730.

Since Sphinx supports generating canonical URLs deprecate our `canonical_url` config and remove the related template code.

Detect if the dirhtml builder is used and is generating invalid URLs, and use our existing logic to generate the correct URL. The workaround will be skipped if it looks like Sphinx has fixed the bug.

closes #47 