### PR TITLE
Render `.. click:run::` code blocks with `shell-session` lexer

### DIFF
--- a/src/pallets_sphinx_themes/themes/click/domain.py
+++ b/src/pallets_sphinx_themes/themes/click/domain.py
@@ -242,7 +242,7 @@ class RunExampleDirective(Directive):
             runner.close()
             raise
 
-        doc.append(".. sourcecode:: text", "")
+        doc.append(".. sourcecode:: shell-session", "")
         doc.append("", "")
 
         for line in rv:


### PR DESCRIPTION
Pygments provides a [dedicated `shell-session` lexer](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashSessionLexer) that is perfect to render CLI calls with their output.

This is a little tweak to use it for `.. click:run::` code blocks.