### PR TITLE
Use text-decoration for underlines

### DIFF
--- a/src/pallets_sphinx_themes/themes/babel/static/babel.css
+++ b/src/pallets_sphinx_themes/themes/babel/static/babel.css
@@ -11,12 +11,12 @@ h1, h2, h3, h4, h5, h6, p.admonition-title, div.sphinxsidebar input {
 
 a {
   color: #b00;
-  border-color: #b00;
+  text-decoration-color: #b00;
 }
 
 a:hover {
   color: #fc5e1e;
-  border-color: #fc5e1e;
+  text-decoration-color: #fc5e1e;
 }
 
 p.version-warning {

--- a/src/pallets_sphinx_themes/themes/flask/static/flask.css
+++ b/src/pallets_sphinx_themes/themes/flask/static/flask.css
@@ -2,12 +2,12 @@
 
 a, a.reference, a.footnote-reference {
   color: #004b6b;
-  border-color: #004b6b;
+  text-decoration-color: #004b6b;
 }
 
 a:hover {
   color: #6d4100;
-  border-color: #6d4100;
+  text-decoration-color: #6d4100;
 }
 
 p.version-warning {

--- a/src/pallets_sphinx_themes/themes/jinja/static/jinja.css
+++ b/src/pallets_sphinx_themes/themes/jinja/static/jinja.css
@@ -7,12 +7,12 @@ h1, h2, h3, h4, h5, h6, p.admonition-title, div.sphinxsidebar input {
 
 a, a.reference, a.footnote-reference {
   color: #a00;
-  border-color: #a00;
+  text-decoration-color: #a00;
 }
 
 a:hover {
   color: #d00;
-  border-color: #d00;
+  text-decoration-color: #d00;
 }
 
 p.version-warning {

--- a/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
+++ b/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
@@ -167,12 +167,13 @@ p.version-warning a {
 /* -- body styles --------------------------------------------------- */
 
 a {
-  text-decoration: none;
-  border-bottom: 1px dotted #000;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: #000;
 }
 
 a:hover {
-  border-bottom-style: solid;
+  text-decoration-style: solid;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/src/pallets_sphinx_themes/themes/werkzeug/static/werkzeug.css
+++ b/src/pallets_sphinx_themes/themes/werkzeug/static/werkzeug.css
@@ -2,12 +2,12 @@
 
 a, a.reference, a.footnote-reference {
   color: #185f6d;
-  border-color: #185f6d;
+  text-decoration-color: #185f6d;
 }
 
 a:hover {
   color: #2794aa;
-  border-color: #2794aa;
+  text-decoration-color: #2794aa;
 }
 
 p.version-warning {


### PR DESCRIPTION
Seems like you’re using an ancient hack for some reason.

The better alternative might be to use CSS variables for everything, but that’s a big refactor and this PR is only a small fix.