### PR TITLE
remove Python 2 compatibility code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Version 2.1.1
 
 Unreleased
 
+-   Remove leftover Python 2 compatibility code. :pr:`69`
 -   Dotted underlines on links are smaller. :issue:`70`
 
 

--- a/src/pallets_sphinx_themes/themes/click/domain.py
+++ b/src/pallets_sphinx_themes/themes/click/domain.py
@@ -6,7 +6,6 @@ import tempfile
 from functools import partial
 
 import click
-from click._compat import text_type
 from click.testing import CliRunner
 from click.testing import EchoingStdin
 from docutils import nodes
@@ -67,7 +66,7 @@ def patch_modules():
 class ExampleRunner(CliRunner):
     def __init__(self):
         super().__init__(echo_stdin=True)
-        self.namespace = {"click": click, "__file__": "dummy.py", "str": text_type}
+        self.namespace = {"click": click, "__file__": "dummy.py"}
 
     @contextlib.contextmanager
     def isolation(self, *args, **kwargs):


### PR DESCRIPTION
This removes the outdated reference to old `click`'s Python 2 compatibility hack.

This will allow to remove the workaround in `click/docs/conf.py`: https://github.com/pallets/click/blob/1de080b90a82c0ae4e34ba187bc3e945e8a85563/docs/conf.py#L4-L7

For the record, this will also allow me to remove my hack for Click Extra at: https://github.com/kdeldycke/click-extra/blob/7b8d6c6fb5ad2bbc1df08bfafe74c68c9c17c40e/click_extra/sphinx.py#L69-L87 