### PR TITLE
compatibility with sphinx 7.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Compatibility with changes in Sphinx 7.3. :pr:`100`
 
 
 Version 2.1.1

--- a/src/pallets_sphinx_themes/theme_check.py
+++ b/src/pallets_sphinx_themes/theme_check.py
@@ -1,5 +1,7 @@
 from functools import wraps
 
+from sphinx.theming import HTMLThemeFactory
+
 
 def set_is_pallets_theme(app):
     """Set the ``is_pallets_theme`` config to ``True`` if the current
@@ -10,14 +12,12 @@ def set_is_pallets_theme(app):
 
     theme = getattr(app.builder, "theme", None)
 
-    while theme is not None:
-        if theme.name == "pocoo":
-            app.config.is_pallets_theme = True
-            break
-
-        theme = theme.base
-    else:
+    if theme is None:
         app.config.is_pallets_theme = False
+        return
+
+    pocoo_dir = HTMLThemeFactory(app).create("pocoo").get_theme_dirs()[0]
+    app.config.is_pallets_theme = pocoo_dir in theme.get_theme_dirs()
 
 
 def only_pallets_theme(default=None):


### PR DESCRIPTION
Sphinx 7.3 changed how themes were loaded and removed some previously "public" (but undocumented) attributes. We previously walked up `theme.base` to check if a theme was `pocoo`. That's no longer available. Instead, get the `pocoo` theme, get its first directory, and check if it's in the current theme's directories.
