### PR TITLE
canonical url doesn't use page redirect

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Version 2.3.0
 
 Unreleased
 
+-   When getting the canonical URL on Read the Docs, replace the path with
+    ``/en/stable/`` instead of ``/page/``. This can be configured with
+    ``rtd_canonical_path``. :pr:`119`
+
 
 Version 2.2.0
 -------------

--- a/src/pallets_sphinx_themes/__init__.py
+++ b/src/pallets_sphinx_themes/__init__.py
@@ -25,6 +25,7 @@ def setup(app):
             app.add_html_theme(name, path)
 
     app.add_config_value("is_pallets_theme", None, "html")
+    app.add_config_value("rtd_canonical_path", "/en/stable/", "html")
 
     # Use the sphinx-notfound-page extension to generate a 404 page with valid
     # URLs. Only configure it if it's not already configured.
@@ -67,16 +68,16 @@ def setup(app):
 @only_pallets_theme()
 def find_base_canonical_url(app: Sphinx) -> None:
     """When building on Read the Docs, build the base canonical URL from the
-    environment variable if it's not given in the config. Read the Docs has a
-    special `/page/<path>` rule that redirects any path to the current version
-    of the docs, so that's used as the canonical link.
+    environment variable if it's not given in the config. Replace the path with
+    ``rtd_canonical_path``, which defaults to ``/en/stable/``.
     """
     if app.config.html_baseurl:
         return
 
     if "READTHEDOCS_CANONICAL_URL" in os.environ:
         parts = urlsplit(os.environ["READTHEDOCS_CANONICAL_URL"])
-        app.config.html_baseurl = f"{parts.scheme}://{parts.netloc}/page/"
+        path = app.config.rtd_canonical_path
+        app.config.html_baseurl = f"{parts.scheme}://{parts.netloc}{path}"
 
 
 @only_pallets_theme()


### PR DESCRIPTION
Pallets is switching to use a `stable` branch so that `/en/stable/` represents the current maintained release (like ".x" branches before). Use that as the canonical path, and also allow a project to configure it with `rtd_canonical_path`. Ideally search engines handle this better than `/page/` redirects.