### PR TITLE
allow disabling version banner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Unreleased
 
 -   When getting the canonical URL on Read the Docs, replace the path with
     ``/en/stable/`` instead of ``/page/``. This can be configured with
-    ``rtd_canonical_path``. :pr:`119`
+    ``rtd_canonical_path``. :pr:`122`
+-   The version banner can be disabled by setting ``version_banner = False``.
+    On Read the Docs, it is disabled when building the ``stable`` version or
+    PRs. :pr:`123`
 
 
 Version 2.2.0


### PR DESCRIPTION
``version_banner = False`` can be set to disable including the version banner JavaScript. It will also be disabled on Read the Docs when building `stable` or PRs. The `stable` branch is becoming the default, there's no need to make PyPI requests for that version since we know it's the canonical one.

The banner also works if no `<link rel=canonical` tag is present. The version is only text and not a link in that case.