### PR TITLE
Remove Garamond from docs on Windows

### DIFF
--- a/src/pallets_sphinx_themes/themes/jinja/static/jinja.css
+++ b/src/pallets_sphinx_themes/themes/jinja/static/jinja.css
@@ -2,7 +2,7 @@
 @import url("https://fonts.googleapis.com/css?family=Crimson+Text");
 
 h1, h2, h3, h4, h5, h6, p.admonition-title, div.sphinxsidebar input {
-  font-family: "Crimson Text", "Garamond", "Georgia", serif;
+  font-family: "Crimson Text", "Georgia", serif;
 }
 
 a, a.reference, a.footnote-reference {

--- a/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
+++ b/src/pallets_sphinx_themes/themes/pocoo/static/pocoo.css
@@ -8,7 +8,7 @@ html {
 }
 
 body {
-  font-family: 'Garamond', 'Georgia', serif;
+  font-family: 'Georgia', serif;
   font-size: 17px;
   background-color: #fff;
   color: #3e4349;
@@ -494,7 +494,7 @@ table.footnote td {
 }
 
 .sphinx-tabs .ui.menu {
-  font-family: 'Garamond', 'Georgia', serif !important;
+  font-family: 'Georgia', serif !important;
 }
 
 .sphinx-tabs .ui.attached.menu {


### PR DESCRIPTION
The docs for Flask and other projects render in the font Garamond on Windows, while they render in Georgia on macOS.

I find Garamond hard to read. There is a screenshot of what the docs look like on Windows at [this previous discussion](https://github.com/orgs/pallets/discussions/5162) of the font issue. Garamond is small, and I think its serifs are not suited well for screens.

From that discussion, I understand @davidism prefers serif fonts for body text, and I think Georgia would be better on Windows for both readability and consistency with macOS.